### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,6 @@
 		    	<properties>
 				<additionalparam>-Xdoclint:none</additionalparam>
 			</properties>
-		</profiles>
-	</profile>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -194,4 +194,15 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>disable-javadoc-doclint</id>
+		    	<activation>
+				<jdk>[1.8,)</jdk>
+		    	</activation>
+		    	<properties>
+				<additionalparam>-Xdoclint:none</additionalparam>
+			</properties>
+		</profile>
+	</profile
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -204,5 +204,5 @@
 				<additionalparam>-Xdoclint:none</additionalparam>
 			</properties>
 		</profile>
-	</profile
+	</profile>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,6 @@
 		    	<properties>
 				<additionalparam>-Xdoclint:none</additionalparam>
 			</properties>
-		</profile>
+		</profiles>
 	</profile>
 </project>


### PR DESCRIPTION
fixes javadoc issue on build tests by skipping doclints on javadoc